### PR TITLE
Added stall-value to configuration

### DIFF
--- a/src/controller/stepper/Stepper.cpp
+++ b/src/controller/stepper/Stepper.cpp
@@ -31,7 +31,7 @@ void Stepper::init() {
     _driver->blank_time(5);
     _driver->rms_current(_config.maxCurrent);
     _driver->microsteps(_config.microstepsPerStep);
-    _driver->sgt(DRIVER_STALL_VALUE);
+    _driver->sgt(_config.stall);
     _driver->sfilt(true);
 
     // StallGuard/Coolstep config
@@ -392,6 +392,7 @@ void Stepper::handle() {
     // Handle the current recipe, that was already started at some point in the past
     switch(_currentRecipe.mode){
         case HOMING:
+            logPrint(WARNING, WARNING, "(%d)Ferrariload: %d\n", _config.stall, _stepperStatus.load); // TODO - debug
             // Wait for stopper to be hit to set home
             if (isStartSpeedReached() && _stepperStatus.load == 100) {
                 _homeConsecutiveBumpCounter++;

--- a/src/controller/stepper/Stepper.h
+++ b/src/controller/stepper/Stepper.h
@@ -47,7 +47,6 @@ class Stepper : public BaseController{
     FastAccelStepper *_stepper = NULL;
 
     // Hardcoded configuration
-    const int8_t DRIVER_STALL_VALUE = 8;  // [-64..63] stall value of the tmcstepper-driver. Defines when the load value will read 0 and the stall flag will be triggered. Higher = less sensitive reading, lower = more sensitive reading
     const uint16_t DEFAULT_ACCELERATION = 10000;  // Default stepper acceleration
     const float DEFAULT_HOMING_SPEED_RPM = 60; // Default homing speed in rotations per minute
     const uint8_t HOMING_BUMPS_NEEDED = 2; // Number of consecutive bumps (100% load) needed to be sure that we have found the home position and not just measured a glitched load value

--- a/src/controller/stepper/StepperTest.h
+++ b/src/controller/stepper/StepperTest.h
@@ -17,6 +17,7 @@ struct stepperConfiguration_s {
     float stepsPerRotation;      // hard steps per rotation (NEMA17 - 200)
     float mmPerRotation;  // mm stepper moves, mm filament pulled every rotation
     float gearRatio; // gear-dependend ratio for motor-rotations to the rotations of the moved object (like a spool). 1 = 1:1 = direct 
+    int8_t stall; // [-64..63] stall value of the tmcstepper-driver. Defines when the load value will read 0 and the stall flag will be triggered. Higher = less sensitive reading, lower = more sensitive reading
     struct Pins {
         uint8_t en;    // SPI enable pin
         uint8_t dir;   // stepper direcion pin

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,7 @@ stepperConfiguration_s spoolConfig = {
     .stepsPerRotation = 200,
     .mmPerRotation = 2800,
     .gearRatio = 5.18,
+    .stall = 8,
     .pins = {
         .en = 12,
         .dir = 16,
@@ -21,6 +22,7 @@ stepperConfiguration_s ferrariConfig = {
     .stepsPerRotation = 200,
     .mmPerRotation = 8,
     .gearRatio = 1,
+    .stall = 5, // 5 = new ferrari-motor, 10 (or 9) = old ferrari-motor
     .pins = {
         .en = 12,
         .dir = 14,
@@ -35,6 +37,7 @@ stepperConfiguration_s pullerConfig = {
     .stepsPerRotation = 200,
     .mmPerRotation = 10,
     .gearRatio = 1,
+    .stall = 8,
     .pins = {
         .en = 12,
         .dir = 27,
@@ -94,7 +97,7 @@ void loop() {
             case 'h': // Home
                 Serial.println("[CMD]: home()");
                 //ferrari.moveHome(70);
-                ferrari.movePosition(70, 63);
+                ferrari.movePosition(120, 135);
                 break;
             case 'H': // Home
                 Serial.println("[CMD]: home()");


### PR DESCRIPTION
As we are switching to a bigger 59Ncm 2A Stepper Motor on the Winder Ferrari, an option to adjust sensorless homing sensitivity is required. The TMC library allows setting a `driver->sgt()` value that does exactly that. Thus a new stall parameter has been included into the stepper struct, which makes the new library version a breaking change.